### PR TITLE
Added tagged spec stats to mspec.

### DIFF
--- a/lib/mspec/runner/actions/tally.rb
+++ b/lib/mspec/runner/actions/tally.rb
@@ -1,8 +1,8 @@
 class Tally
-  attr_accessor :files, :examples, :expectations, :failures, :errors, :guards
+  attr_accessor :files, :examples, :expectations, :failures, :errors, :guards, :tagged
 
   def initialize
-    @files = @examples = @expectations = @failures = @errors = @guards = 0
+    @files = @examples = @expectations = @failures = @errors = @guards = @tagged = 0
   end
 
   def files!(add=1)
@@ -29,6 +29,10 @@ class Tally
     @guards += add
   end
 
+  def tagged!(add=1)
+    @tagged += add
+  end
+
   def file
     pluralize files, "file"
   end
@@ -53,9 +57,16 @@ class Tally
     pluralize guards, "guard"
   end
 
+  def tag
+    "#{tagged} tagged"
+  end
+
   def format
     results = [ file, example, expectation, failure, error ]
-    results << guard if [:report, :report_on, :verify].any? { |m| MSpec.mode? m }
+    if [:report, :report_on, :verify].any? { |m| MSpec.mode? m }
+      results << guard
+      results << tag
+    end
     results.join(", ")
   end
 
@@ -78,6 +89,7 @@ class TallyAction
     MSpec.register :load,        self
     MSpec.register :exception,   self
     MSpec.register :example,     self
+    MSpec.register :tagged,      self
     MSpec.register :expectation, self
   end
 
@@ -85,6 +97,7 @@ class TallyAction
     MSpec.unregister :load,        self
     MSpec.unregister :exception,   self
     MSpec.unregister :example,     self
+    MSpec.unregister :tagged,      self
     MSpec.unregister :expectation, self
   end
 
@@ -108,6 +121,11 @@ class TallyAction
   # of examples.
   def example(state, block)
     @counter.examples!
+  end
+
+  def tagged(state)
+    @counter.examples!
+    @counter.tagged!
   end
 
   def format

--- a/lib/mspec/runner/context.rb
+++ b/lib/mspec/runner/context.rb
@@ -182,7 +182,14 @@ class ContextState
   # Removes filtered examples. Returns true if there are examples
   # left to evaluate.
   def filter_examples
-    @examples.reject! { |ex| ex.filtered? }
+    filtered, @examples = @examples.partition do |ex|
+      ex.filtered?
+    end
+
+    filtered.each do |ex|
+      MSpec.actions :tagged, ex
+    end
+
     not @examples.empty?
   end
 

--- a/lib/mspec/runner/formatters/yaml.rb
+++ b/lib/mspec/runner/formatters/yaml.rb
@@ -40,5 +40,6 @@ class YamlFormatter < DottedFormatter
     print "expectations: ", @tally.counter.expectations, "\n"
     print "failures: ",     @tally.counter.failures,     "\n"
     print "errors: ",       @tally.counter.errors,       "\n"
+    print "tagged: ",       @tally.counter.tagged,       "\n"
   end
 end

--- a/spec/runner/actions/tally_spec.rb
+++ b/spec/runner/actions/tally_spec.rb
@@ -191,7 +191,7 @@ describe Tally, "#format" do
     @tally.errors!
     @tally.guards!
     @tally.format.should ==
-      "1 file, 2 examples, 4 expectations, 0 failures, 1 error, 1 guard"
+      "1 file, 2 examples, 4 expectations, 0 failures, 1 error, 1 guard, 0 tagged"
   end
 
   it "includes guards if MSpec is in report mode" do
@@ -202,7 +202,7 @@ describe Tally, "#format" do
     @tally.errors!
     @tally.guards! 2
     @tally.format.should ==
-      "1 file, 2 examples, 4 expectations, 0 failures, 1 error, 2 guards"
+      "1 file, 2 examples, 4 expectations, 0 failures, 1 error, 2 guards, 0 tagged"
   end
 
   it "includes guards if MSpec is in report_on mode" do
@@ -213,7 +213,7 @@ describe Tally, "#format" do
     @tally.errors!
     @tally.guards! 2
     @tally.format.should ==
-      "1 file, 2 examples, 4 expectations, 0 failures, 1 error, 2 guards"
+      "1 file, 2 examples, 4 expectations, 0 failures, 1 error, 2 guards, 0 tagged"
   end
 end
 
@@ -324,8 +324,9 @@ describe TallyAction, "#register" do
 
   it "registers itself with MSpec for appropriate actions" do
     MSpec.should_receive(:register).with(:load, @tally)
-    MSpec.should_receive(:register).with(:example, @tally)
     MSpec.should_receive(:register).with(:exception, @tally)
+    MSpec.should_receive(:register).with(:example, @tally)
+    MSpec.should_receive(:register).with(:tagged, @tally)
     MSpec.should_receive(:register).with(:expectation, @tally)
     @tally.register
   end
@@ -341,6 +342,7 @@ describe TallyAction, "#unregister" do
     MSpec.should_receive(:unregister).with(:load, @tally)
     MSpec.should_receive(:unregister).with(:exception, @tally)
     MSpec.should_receive(:unregister).with(:example, @tally)
+    MSpec.should_receive(:unregister).with(:tagged, @tally)
     MSpec.should_receive(:unregister).with(:expectation, @tally)
     @tally.unregister
   end


### PR DESCRIPTION
I haven't updated all the standard formatters yet.  Before sinking the time into that, I wanted to make sure this would be a welcomed change.

I've pinged @brixen, @enebo, @headius, and @eregon on this when I did the original work a month or so ago.  But at the time it was just me explaining what I was looking to do and it's possible I didn't explain it well.  So now here's some code to look at.

The most controversial change, I think, is the total example count is now influenced by the number of tagged specs.  Depending on how you want to look at it, it makes some math easier.  Success rate is likely a more accurate indicator.  E.g., if you pass 5,000 specs but tag 10,000, a success rate of 100% rather dubious.  The converse is it could complicate error and failure rates, since you probably don't want to take the tagged specs into account in that case.  I'm not sure if there's really a right answer.  I think having tagged specs influence the example count is a more accurate portrayal of spec status, even with its own flaws.  But I welcome feedback on the PR.